### PR TITLE
fix: correct 'ocurred' to 'occurred' typo in hooks.go

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -126,7 +126,7 @@ func bindAppHooks(app core.App) {
 			}
 
 			if err := form.Submit(); err != nil {
-				return e.BadRequestError("An error occured during the submission.", err)
+				return e.BadRequestError("An error occurred during the submission.", err)
 			}
 
 			return e.NoContent(http.StatusNoContent)


### PR DESCRIPTION
Hi @presentator 👋 — this PR fixes the typo 'ocurred' → 'occurred' in hooks.go line 129, in the BadRequestError message shown to users when a form submission fails. Simple 1-line fix, happy to adjust if needed!